### PR TITLE
Improve FocusTrap focus management

### DIFF
--- a/packages/core-foundation/src/FocusTrap.tsx
+++ b/packages/core-foundation/src/FocusTrap.tsx
@@ -10,20 +10,40 @@ export const FocusTrap: React.FC<FocusTrapProps> = ({
   children,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!active || !ref.current) return;
     const container = ref.current;
+
+    const focusFirst = () => {
+      const focusable =
+        container.querySelector<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        ) || container;
+      focusable?.focus();
+    };
+
+    if (!container.contains(document.activeElement)) {
+      previouslyFocused.current = document.activeElement as HTMLElement | null;
+      focusFirst();
+    }
+
     const handleFocus = (event: FocusEvent) => {
       if (!container.contains(event.target as Node)) {
-        const focusable = container.querySelector<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        focusable?.focus();
+        previouslyFocused.current = event.target as HTMLElement;
+        focusFirst();
       }
     };
+
     document.addEventListener('focusin', handleFocus);
-    return () => document.removeEventListener('focusin', handleFocus);
+    return () => {
+      document.removeEventListener('focusin', handleFocus);
+      const prev = previouslyFocused.current;
+      if (prev && document.contains(prev)) {
+        prev.focus();
+      }
+    };
   }, [active]);
 
   return <div ref={ref}>{children}</div>;

--- a/packages/core-foundation/src/__tests__/FocusTrap.test.tsx
+++ b/packages/core-foundation/src/__tests__/FocusTrap.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { render } from '@testing-library/react';
+import React, { useState } from 'react';
+import { render, act } from '@testing-library/react';
 import FocusTrap from '../FocusTrap';
 
 describe('FocusTrap', () => {
@@ -17,5 +17,36 @@ describe('FocusTrap', () => {
 
     outside.focus();
     expect(document.activeElement).toBe(inside);
+  });
+
+  it('restores focus on unmount', () => {
+    const Wrapper = () => {
+      const [open, setOpen] = useState(true);
+      return (
+        <div>
+          <button>trigger</button>
+          {open && (
+            <FocusTrap>
+              <button>inside</button>
+            </FocusTrap>
+          )}
+          <button onClick={() => setOpen(false)}>close</button>
+        </div>
+      );
+    };
+
+    const { getByText } = render(<Wrapper />);
+    const trigger = getByText('trigger') as HTMLButtonElement;
+    const close = getByText('close') as HTMLButtonElement;
+    const inside = getByText('inside') as HTMLButtonElement;
+
+    trigger.focus();
+    expect(document.activeElement).toBe(inside);
+
+    act(() => {
+      close.click();
+    });
+
+    expect(document.activeElement).toBe(trigger);
   });
 });


### PR DESCRIPTION
## Summary
- enhance FocusTrap to automatically focus the first element when opened and restore focus on close
- test focus restoration behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e7b0b4608324b77f497ece22f446