### PR TITLE
Add ARIA attribute support

### DIFF
--- a/packages/core-foundation/src/FocusTrap.tsx
+++ b/packages/core-foundation/src/FocusTrap.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-export interface FocusTrapProps {
+export interface FocusTrapProps extends React.HTMLAttributes<HTMLDivElement> {
   active?: boolean;
   children: React.ReactNode;
 }
@@ -8,6 +8,7 @@ export interface FocusTrapProps {
 export const FocusTrap: React.FC<FocusTrapProps> = ({
   active = true,
   children,
+  ...rest
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
@@ -46,7 +47,11 @@ export const FocusTrap: React.FC<FocusTrapProps> = ({
     };
   }, [active]);
 
-  return <div ref={ref}>{children}</div>;
+  return (
+    <div ref={ref} {...rest}>
+      {children}
+    </div>
+  );
 };
 
 export default FocusTrap;

--- a/packages/core-foundation/src/__tests__/FocusTrap.test.tsx
+++ b/packages/core-foundation/src/__tests__/FocusTrap.test.tsx
@@ -49,4 +49,14 @@ describe('FocusTrap', () => {
 
     expect(document.activeElement).toBe(trigger);
   });
+
+  it('forwards extra props to the container', () => {
+    const { getByRole } = render(
+      <FocusTrap role="dialog" aria-label="modal">
+        <button>inside</button>
+      </FocusTrap>
+    );
+    const container = getByRole('dialog');
+    expect(container).toHaveAttribute('aria-label', 'modal');
+  });
 });

--- a/packages/htmleditor-core/README.md
+++ b/packages/htmleditor-core/README.md
@@ -26,10 +26,16 @@ function App() {
       value={value}
       onChange={setValue}
       plugins={[toolbarPlugin, imageUpload]}
+      aria-label="Rich text editor"
     />
   );
 }
 ```
+
+### Accessibility
+
+`HtmlEditorCore` forwards ARIA attributes like `aria-label`, `aria-labelledby`
+and `aria-describedby` to the underlying editor element.
 
 ## Development
 

--- a/packages/htmleditor-core/src/HtmlEditorCore.tsx
+++ b/packages/htmleditor-core/src/HtmlEditorCore.tsx
@@ -14,6 +14,12 @@ export interface HtmlEditorCoreProps {
   readOnly?: boolean;
   placeholder?: string;
   plugins?: HtmlEditorPlugin[];
+  /** Accessible label for the editor */
+  'aria-label'?: string;
+  /** ID of element labeling the editor */
+  'aria-labelledby'?: string;
+  /** ID of element describing the editor */
+  'aria-describedby'?: string;
 }
 
 export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
@@ -23,6 +29,9 @@ export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
   readOnly = false,
   placeholder,
   plugins = [],
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-describedby': ariaDescribedBy,
 }) => {
   const modules = useMemo(() => {
     const base: Record<string, unknown> = {};
@@ -52,6 +61,9 @@ export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
       modules={modules}
       formats={formats}
       placeholder={placeholder}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
     />
   );
 };

--- a/packages/htmleditor-core/src/__tests__/HtmlEditorCore.test.tsx
+++ b/packages/htmleditor-core/src/__tests__/HtmlEditorCore.test.tsx
@@ -6,6 +6,7 @@ import { toolbarPlugin } from '@lib/htmleditor-toolbar';
 jest.mock('react-quill', () => {
   const Mock: React.FC<Record<string, unknown>> = (props) => (
     <div
+      {...props}
       data-testid="quill"
       data-modules={JSON.stringify(props.modules)}
       data-formats={JSON.stringify(props.formats)}
@@ -23,5 +24,11 @@ describe('HtmlEditorCore', () => {
     const formats = JSON.parse(el.getAttribute('data-formats')!);
     expect(modules.toolbar).toBeDefined();
     expect(formats).toEqual(expect.arrayContaining(['bold', 'italic']));
+  });
+
+  it('passes ARIA attributes to ReactQuill', () => {
+    render(<HtmlEditorCore aria-label="editor" />);
+    const el = screen.getByLabelText('editor');
+    expect(el).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- forward ARIA attributes in HtmlEditorCore and FocusTrap
- document accessible usage of HtmlEditorCore
- add tests for new ARIA props

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849e77868248324a09f5e76f3f00c17