### PR TITLE
Improve accessibility features

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,4 +16,7 @@ module.exports = {
     'plugin:prettier/recommended'
   ],
   settings: { react: { version: 'detect' } },
+  rules: {
+    'react/prop-types': 'off',
+  },
 };

--- a/packages/core-foundation/README.md
+++ b/packages/core-foundation/README.md
@@ -31,6 +31,7 @@ The provider sets CSS variables on `document.documentElement` based on the curre
 ## LocaleProvider
 
 Use `LocaleProvider` to supply translated messages and switch locales.
+The provider also updates the document `lang` attribute to match the current locale.
 
 ```tsx
 import { LocaleProvider, useLocale } from '@lib/core-foundation';
@@ -68,4 +69,17 @@ import { FocusTrap } from '@lib/core-foundation';
     <button>Second</button>
   </dialog>
 </FocusTrap>;
+```
+
+## VisuallyHidden
+
+`VisuallyHidden` renders content that is hidden visually but still available to screen readers. Use it to provide additional instructions or context for assistive technology users.
+
+```tsx
+import { VisuallyHidden } from '@lib/core-foundation';
+
+<button>
+  Submit
+  <VisuallyHidden>submits the form</VisuallyHidden>
+</button>
 ```

--- a/packages/core-foundation/src/FocusTrap.tsx
+++ b/packages/core-foundation/src/FocusTrap.tsx
@@ -8,6 +8,7 @@ export interface FocusTrapProps extends React.HTMLAttributes<HTMLDivElement> {
 export const FocusTrap: React.FC<FocusTrapProps> = ({
   active = true,
   children,
+  tabIndex = -1,
   ...rest
 }) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -48,7 +49,7 @@ export const FocusTrap: React.FC<FocusTrapProps> = ({
   }, [active]);
 
   return (
-    <div ref={ref} {...rest}>
+    <div ref={ref} tabIndex={tabIndex} {...rest}>
       {children}
     </div>
   );

--- a/packages/core-foundation/src/LocaleProvider.tsx
+++ b/packages/core-foundation/src/LocaleProvider.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  useEffect,
+} from 'react';
 
 export type Messages = Record<string, string>;
 
@@ -42,6 +48,10 @@ export const LocaleProvider: React.FC<LocaleProviderProps> = ({
     },
     [allMessages]
   );
+
+  useEffect(() => {
+    document.documentElement.setAttribute('lang', locale);
+  }, [locale]);
 
   const register = useCallback((loc: string, msgs: Messages) => {
     setAllMessages((prev) => ({ ...prev, [loc]: { ...prev[loc], ...msgs } }));

--- a/packages/core-foundation/src/VisuallyHidden.tsx
+++ b/packages/core-foundation/src/VisuallyHidden.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-export const VisuallyHidden: React.FC<React.HTMLAttributes<HTMLSpanElement>> = ({
-  children,
-  style,
-  ...rest
-}) => (
+export const VisuallyHidden: React.FC<
+  React.HTMLAttributes<HTMLSpanElement>
+> = ({ children, style, ...rest }) => (
   <span
     style={{
       position: 'absolute',

--- a/packages/core-foundation/src/VisuallyHidden.tsx
+++ b/packages/core-foundation/src/VisuallyHidden.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export const VisuallyHidden: React.FC<React.HTMLAttributes<HTMLSpanElement>> = ({
+  children,
+  style,
+  ...rest
+}) => (
+  <span
+    style={{
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+      padding: 0,
+      margin: '-1px',
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      border: 0,
+      ...(style || {}),
+    }}
+    {...rest}
+  >
+    {children}
+  </span>
+);
+
+export default VisuallyHidden;

--- a/packages/core-foundation/src/__tests__/FocusTrap.test.tsx
+++ b/packages/core-foundation/src/__tests__/FocusTrap.test.tsx
@@ -58,5 +58,6 @@ describe('FocusTrap', () => {
     );
     const container = getByRole('dialog');
     expect(container).toHaveAttribute('aria-label', 'modal');
+    expect(container).toHaveAttribute('tabindex', '-1');
   });
 });

--- a/packages/core-foundation/src/__tests__/LocaleProvider.test.tsx
+++ b/packages/core-foundation/src/__tests__/LocaleProvider.test.tsx
@@ -29,4 +29,13 @@ describe('LocaleProvider', () => {
     });
     expect(getByText('Hola')).toBeInTheDocument();
   });
+
+  it('sets the lang attribute on the document element', () => {
+    render(
+      <LocaleProvider initialLocale="en" messages={messages}>
+        <div />
+      </LocaleProvider>
+    );
+    expect(document.documentElement.getAttribute('lang')).toBe('en');
+  });
 });

--- a/packages/core-foundation/src/index.ts
+++ b/packages/core-foundation/src/index.ts
@@ -1,3 +1,4 @@
 export { ThemeProvider, useTheme, type ThemeMode } from './ThemeProvider';
 export { LocaleProvider, useLocale, type Messages } from './LocaleProvider';
 export { FocusTrap, type FocusTrapProps } from './FocusTrap';
+export { VisuallyHidden } from './VisuallyHidden';

--- a/packages/htmleditor-core/README.md
+++ b/packages/htmleditor-core/README.md
@@ -36,6 +36,7 @@ function App() {
 
 `HtmlEditorCore` forwards ARIA attributes like `aria-label`, `aria-labelledby`
 and `aria-describedby` to the underlying editor element.
+It also renders a visually hidden help text for screen reader users. Customize this message via the `screenReaderHelpText` prop.
 
 ## Development
 

--- a/packages/htmleditor-core/src/HtmlEditorCore.tsx
+++ b/packages/htmleditor-core/src/HtmlEditorCore.tsx
@@ -56,9 +56,7 @@ export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
   }, [plugins]);
 
   const hintId = useId();
-  const describedBy = ariaDescribedBy
-    ? `${ariaDescribedBy} ${hintId}`
-    : hintId;
+  const describedBy = ariaDescribedBy ? `${ariaDescribedBy} ${hintId}` : hintId;
 
   return (
     <>

--- a/packages/htmleditor-core/src/HtmlEditorCore.tsx
+++ b/packages/htmleditor-core/src/HtmlEditorCore.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useId } from 'react';
+import { VisuallyHidden } from '@lib/core-foundation';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
@@ -20,6 +21,8 @@ export interface HtmlEditorCoreProps {
   'aria-labelledby'?: string;
   /** ID of element describing the editor */
   'aria-describedby'?: string;
+  /** Additional help text for screen readers */
+  screenReaderHelpText?: string;
 }
 
 export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
@@ -32,6 +35,7 @@ export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
   'aria-describedby': ariaDescribedBy,
+  screenReaderHelpText = 'Rich text editor',
 }) => {
   const modules = useMemo(() => {
     const base: Record<string, unknown> = {};
@@ -51,20 +55,28 @@ export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
     return Array.from(new Set(base));
   }, [plugins]);
 
+  const hintId = useId();
+  const describedBy = ariaDescribedBy
+    ? `${ariaDescribedBy} ${hintId}`
+    : hintId;
+
   return (
-    <ReactQuill
-      theme="snow"
-      value={value}
-      defaultValue={defaultValue}
-      onChange={onChange}
-      readOnly={readOnly}
-      modules={modules}
-      formats={formats}
-      placeholder={placeholder}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-      aria-describedby={ariaDescribedBy}
-    />
+    <>
+      <VisuallyHidden id={hintId}>{screenReaderHelpText}</VisuallyHidden>
+      <ReactQuill
+        theme="snow"
+        value={value}
+        defaultValue={defaultValue}
+        onChange={onChange}
+        readOnly={readOnly}
+        modules={modules}
+        formats={formats}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={describedBy}
+      />
+    </>
   );
 };
 

--- a/packages/htmleditor-core/src/__tests__/HtmlEditorCore.test.tsx
+++ b/packages/htmleditor-core/src/__tests__/HtmlEditorCore.test.tsx
@@ -27,8 +27,11 @@ describe('HtmlEditorCore', () => {
   });
 
   it('passes ARIA attributes to ReactQuill', () => {
-    render(<HtmlEditorCore aria-label="editor" />);
+    render(<HtmlEditorCore aria-label="editor" screenReaderHelpText="help" />);
     const el = screen.getByLabelText('editor');
     expect(el).toBeInTheDocument();
+    const hint = screen.getByText('help');
+    expect(hint).toHaveAttribute('id');
+    expect(el).toHaveAttribute('aria-describedby', hint.getAttribute('id')!);
   });
 });

--- a/packages/htmleditor-core/vite.config.ts
+++ b/packages/htmleditor-core/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       fileName: (format) => `htmleditor-core.${format}.js`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react-quill'],
+      external: ['react', 'react-dom', 'react-quill', '@lib/core-foundation'],
       output: {
         globals: {
           react: 'React',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "module": "esnext",
     "jsx": "react-jsx",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- add `VisuallyHidden` helper component
- ensure `LocaleProvider` sets document `lang`
- make `FocusTrap` focusable and test tabindex
- provide screen reader hint for `HtmlEditorCore`
- document accessibility improvements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ee21c2288324a480d1046cfdbb1f