### PR TITLE
Add basic RTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This monorepo contains a modular React component library. The first feature is a
 - `@lib/htmleditor-core` – Core Quill wrapper.
 - `@lib/htmleditor-toolbar` – Default toolbar plugin.
 - `@lib/htmleditor-media` – Image upload plugin.
-- `@lib/core-foundation` – Shared utilities including theming and localization.
+- `@lib/core-foundation` – Shared utilities including theming, localization and text direction management.
 
 Run `npm ci` at the repo root, then `npm run build` and `npm test` to build and test all packages. Start Storybook with `npm run storybook` to explore components. The library includes theming and locale providers from `@lib/core-foundation`:
 
@@ -25,10 +25,13 @@ const messages = {
   en: { hello: 'Hello' },
   es: { hello: 'Hola' },
 };
+const directions = { en: 'ltr', es: 'ltr', ar: 'rtl' };
 
 <ThemeProvider>
-  <LocaleProvider initialLocale="en" messages={messages}>
+  <LocaleProvider initialLocale="en" messages={messages} directions={directions}>
     <HtmlEditorCore plugins={[toolbarPlugin, imageUpload]} />
   </LocaleProvider>
 </ThemeProvider>;
 ```
+
+`LocaleProvider` automatically updates the document `lang` and `dir` attributes based on the active locale and the provided `directions` map.

--- a/packages/core-foundation/README.md
+++ b/packages/core-foundation/README.md
@@ -30,8 +30,8 @@ The provider sets CSS variables on `document.documentElement` based on the curre
 
 ## LocaleProvider
 
-Use `LocaleProvider` to supply translated messages and switch locales.
-The provider also updates the document `lang` attribute to match the current locale.
+Use `LocaleProvider` to supply translated messages, switch locales and control text direction.
+The provider updates the document `lang` and `dir` attributes based on the active locale.
 
 ```tsx
 import { LocaleProvider, useLocale } from '@lib/core-foundation';
@@ -40,6 +40,7 @@ const messages = {
   en: { hello: 'Hello' },
   es: { hello: 'Hola' },
 };
+const directions = { en: 'ltr', es: 'ltr', ar: 'rtl' };
 
 function Greeting() {
   const { t, setLocale } = useLocale();
@@ -51,7 +52,7 @@ function Greeting() {
   );
 }
 
-<LocaleProvider initialLocale="en" messages={messages}>
+<LocaleProvider initialLocale="en" messages={messages} directions={directions}>
   <Greeting />
 </LocaleProvider>;
 ```

--- a/packages/core-foundation/src/LocaleProvider.tsx
+++ b/packages/core-foundation/src/LocaleProvider.tsx
@@ -8,17 +8,25 @@ import React, {
 
 export type Messages = Record<string, string>;
 
+export type TextDirection = 'ltr' | 'rtl';
+
 interface LocaleContextValue {
   locale: string;
   messages: Messages;
+  direction: TextDirection;
   setLocale: (locale: string) => void;
-  register: (locale: string, messages: Messages) => void;
+  register: (
+    locale: string,
+    messages: Messages,
+    direction?: TextDirection
+  ) => void;
   t: (key: string) => string;
 }
 
 const LocaleContext = createContext<LocaleContextValue>({
   locale: 'en',
   messages: {},
+  direction: 'ltr',
   setLocale: () => {},
   register: () => {},
   t: (k: string) => k,
@@ -27,17 +35,20 @@ const LocaleContext = createContext<LocaleContextValue>({
 export interface LocaleProviderProps {
   initialLocale?: string;
   messages?: Record<string, Messages>;
+  directions?: Record<string, TextDirection>;
   children: React.ReactNode;
 }
 
 export const LocaleProvider: React.FC<LocaleProviderProps> = ({
   initialLocale = 'en',
   messages = {},
+  directions = {},
   children,
 }) => {
   const [locale, setLocaleState] = useState(initialLocale);
   const [allMessages, setAllMessages] =
     useState<Record<string, Messages>>(messages);
+  const [dirs, setDirs] = useState<Record<string, TextDirection>>(directions);
 
   const setLocale = useCallback(
     (next: string) => {
@@ -51,11 +62,18 @@ export const LocaleProvider: React.FC<LocaleProviderProps> = ({
 
   useEffect(() => {
     document.documentElement.setAttribute('lang', locale);
-  }, [locale]);
+    document.documentElement.setAttribute('dir', dirs[locale] ?? 'ltr');
+  }, [locale, dirs]);
 
-  const register = useCallback((loc: string, msgs: Messages) => {
-    setAllMessages((prev) => ({ ...prev, [loc]: { ...prev[loc], ...msgs } }));
-  }, []);
+  const register = useCallback(
+    (loc: string, msgs: Messages, dir?: TextDirection) => {
+      setAllMessages((prev) => ({ ...prev, [loc]: { ...prev[loc], ...msgs } }));
+      if (dir) {
+        setDirs((prev) => ({ ...prev, [loc]: dir }));
+      }
+    },
+    []
+  );
 
   const t = useCallback(
     (key: string) => {
@@ -69,6 +87,7 @@ export const LocaleProvider: React.FC<LocaleProviderProps> = ({
       value={{
         locale,
         messages: allMessages[locale] ?? {},
+        direction: dirs[locale] ?? 'ltr',
         setLocale,
         register,
         t,

--- a/packages/core-foundation/src/__tests__/LocaleProvider.test.tsx
+++ b/packages/core-foundation/src/__tests__/LocaleProvider.test.tsx
@@ -38,4 +38,17 @@ describe('LocaleProvider', () => {
     );
     expect(document.documentElement.getAttribute('lang')).toBe('en');
   });
+
+  it('applies text direction from props', () => {
+    render(
+      <LocaleProvider
+        initialLocale="ar"
+        messages={{ ar: { hello: 'مرحبا' } }}
+        directions={{ ar: 'rtl' }}
+      >
+        <div />
+      </LocaleProvider>
+    );
+    expect(document.documentElement.getAttribute('dir')).toBe('rtl');
+  });
 });

--- a/packages/core-foundation/src/index.ts
+++ b/packages/core-foundation/src/index.ts
@@ -1,4 +1,9 @@
 export { ThemeProvider, useTheme, type ThemeMode } from './ThemeProvider';
-export { LocaleProvider, useLocale, type Messages } from './LocaleProvider';
+export {
+  LocaleProvider,
+  useLocale,
+  type Messages,
+  type TextDirection,
+} from './LocaleProvider';
 export { FocusTrap, type FocusTrapProps } from './FocusTrap';
 export { VisuallyHidden } from './VisuallyHidden';

--- a/packages/htmleditor-core/src/HtmlEditorCore.tsx
+++ b/packages/htmleditor-core/src/HtmlEditorCore.tsx
@@ -23,6 +23,8 @@ export interface HtmlEditorCoreProps {
   'aria-describedby'?: string;
   /** Additional help text for screen readers */
   screenReaderHelpText?: string;
+  /** Text direction for the editor */
+  dir?: 'ltr' | 'rtl';
 }
 
 export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
@@ -36,6 +38,7 @@ export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
   'aria-labelledby': ariaLabelledBy,
   'aria-describedby': ariaDescribedBy,
   screenReaderHelpText = 'Rich text editor',
+  dir,
 }) => {
   const modules = useMemo(() => {
     const base: Record<string, unknown> = {};
@@ -61,19 +64,21 @@ export const HtmlEditorCore: React.FC<HtmlEditorCoreProps> = ({
   return (
     <>
       <VisuallyHidden id={hintId}>{screenReaderHelpText}</VisuallyHidden>
-      <ReactQuill
-        theme="snow"
-        value={value}
-        defaultValue={defaultValue}
-        onChange={onChange}
-        readOnly={readOnly}
-        modules={modules}
-        formats={formats}
-        placeholder={placeholder}
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
-        aria-describedby={describedBy}
-      />
+      <div dir={dir}>
+        <ReactQuill
+          theme="snow"
+          value={value}
+          defaultValue={defaultValue}
+          onChange={onChange}
+          readOnly={readOnly}
+          modules={modules}
+          formats={formats}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={describedBy}
+        />
+      </div>
     </>
   );
 };

--- a/packages/htmleditor-core/src/__tests__/HtmlEditorCore.test.tsx
+++ b/packages/htmleditor-core/src/__tests__/HtmlEditorCore.test.tsx
@@ -34,4 +34,10 @@ describe('HtmlEditorCore', () => {
     expect(hint).toHaveAttribute('id');
     expect(el).toHaveAttribute('aria-describedby', hint.getAttribute('id')!);
   });
+
+  it('forwards dir prop', () => {
+    render(<HtmlEditorCore dir="rtl" />);
+    const el = screen.getByTestId('quill');
+    expect(el.parentElement).toHaveAttribute('dir', 'rtl');
+  });
 });


### PR DESCRIPTION
## Summary
- add `directions` option to `LocaleProvider` to update `dir` attribute
- export new `TextDirection` type
- allow passing `dir` to `HtmlEditorCore` and forward to wrapper element
- document text direction in READMEs
- test RTL behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849ee5a550083248277e7bed36f58f1